### PR TITLE
Add env suffix to the argocd app names

### DIFF
--- a/bootstrap/prod-application.yaml
+++ b/bootstrap/prod-application.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: billing
+  name: billing-prod
   namespace: openshift-gitops
 spec:
   destination:

--- a/bootstrap/stage-application.yaml
+++ b/bootstrap/stage-application.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: billing
+  name: billing-stage
   namespace: openshift-gitops
 spec:
   destination:

--- a/bootstrap/test-application.yaml
+++ b/bootstrap/test-application.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: billing
+  name: billing-test
   namespace: openshift-gitops
 spec:
   destination:


### PR DESCRIPTION
There is a pipeline task that I want to use for deploying argo apps to the respective namespaces (env) `argocd-sync-and-wait` and it is parametrized by a name of the argo app.

So to distinguish each app instance, the name needs to be unique.